### PR TITLE
replace single rand with pool

### DIFF
--- a/references.go
+++ b/references.go
@@ -1,8 +1,10 @@
 package foodfans
 
 import (
+	"encoding/binary"
 	"math/rand"
 	"strings"
+	"sync"
 	"time"
 
 	. "github.com/redsift/go-foodfans/lookup"
@@ -10,26 +12,43 @@ import (
 
 const sep = "_"
 
-var _default=NewFoodFans(rand.NewSource(time.Now().UnixNano()))
+var _default = NewFoodFans(rand.NewSource(Seed()))
 
 func New() string {
 	return _default.New()
 }
 
 type FoodFans struct {
-	rand *rand.Rand
+	rnd *sync.Pool
 }
 
 func NewFoodFans(src rand.Source) *FoodFans {
-	return &FoodFans{rand: rand.New(src)}
+	return &FoodFans{
+		rnd: &sync.Pool{New: func() interface{} { return rand.New(src) }},
+	}
 }
 
-func (f* FoodFans) New() string {
+func (f *FoodFans) New() string {
+	rng := f.rnd.Get().(*rand.Rand)
+
 	var w strings.Builder
-	w.WriteString(Verb(f.rand.Intn(int(LastVerb))).String())
+
+	w.WriteString(Verb(rng.Intn(int(LastVerb))).String())
 	w.WriteString(sep)
-	w.WriteString(Adjective(f.rand.Intn(int(LastVerb))).String())
+	w.WriteString(Adjective(rng.Intn(int(LastVerb))).String())
 	w.WriteString(sep)
-	w.WriteString(Noun(f.rand.Intn(int(LastVerb))).String())
+	w.WriteString(Noun(rng.Intn(int(LastVerb))).String())
+
+	f.rnd.Put(rng)
+
 	return w.String()
+}
+
+func Seed() int64 {
+	var seed [8]byte
+	if _, err := rand.Read(seed[:]); err != nil {
+		panic("cannot seed math/rand package with cryptographically secure random number generator")
+	}
+
+	return time.Now().UnixNano() * int64(binary.LittleEndian.Uint64(seed[:]))
 }


### PR DESCRIPTION
### Why

The recent panic on staging most likely caused by the race condition

```
Feb 18 10:47:38 ... -rt-c9ccd78d panic: runtime error: index out of range [-1]
...
Feb 18 10:47:38 ... -rt-c9ccd78d math/rand.(*rngSource).Uint64(...)
Feb 18 10:47:38 ... -rt-c9ccd78d 	/usr/local/go/src/math/rand/rng.go:249
...
```

### How

The single instance of `*rand.Rand` replaced with `*sync.Pool` of `*rand.Rand`.
The secure crypto `Seed()` func added as a replacement for the naive `time.Now().UnixNano()`